### PR TITLE
[Refactor] #154 - 코디네이터 리팩토링(job도 수정)

### DIFF
--- a/CERTI-iOS/Application/DIContainer/AppDIContainer.swift
+++ b/CERTI-iOS/Application/DIContainer/AppDIContainer.swift
@@ -208,6 +208,7 @@ extension AppDIContainer {
   
     func makeResumeFactory() -> ResumeFactory {
         return DefaultResumeFactory(
+            fetchJobUseCase: makeFetchJobUseCase(),
             fetchAcquisitionListUseCase: makeFetchAcquisitionListUseCase(),
             fetchAcquisitionDetailUseCase: makeFetchAcquisitionDetailUseCase(),
             deleteAcquisitionUseCase: makeDeleteAcquisitionUseCase(),

--- a/CERTI-iOS/Data/Network/Job/JobService.swift
+++ b/CERTI-iOS/Data/Network/Job/JobService.swift
@@ -10,14 +10,14 @@ import Foundation
 import Moya
 
 protocol JobsServiceProtocol {
-    func getFetchJob() async -> Result<JobListResponseDTO, NetworkError>
+    func fetchJob() async -> Result<JobListResponseDTO, NetworkError>
     func editJob(jobNameList: EditJobRequestDTO) async -> Result<Void, NetworkError>
 }
 
 final class JobService: BaseService, JobsServiceProtocol {
     private let provider = MoyaProvider<JobAPI>.init(plugins: [MoyaPlugin()])
 
-    func getFetchJob() async -> Result<JobListResponseDTO, NetworkError> {
+    func fetchJob() async -> Result<JobListResponseDTO, NetworkError> {
         return await requestDecodable(provider, .fetchJob)
     }
     func editJob(jobNameList: EditJobRequestDTO) async -> Result<Void, NetworkError> {

--- a/CERTI-iOS/Data/Repositories/DefaultJobRepository.swift
+++ b/CERTI-iOS/Data/Repositories/DefaultJobRepository.swift
@@ -17,8 +17,8 @@ final class DefaultJobRepository: JobRepository {
         self.service = service
     }
 
-    func getFetchJob() async -> Result<JobEntity, NetworkError> {
-        let result = await service.getFetchJob()
+    func fetchJob() async -> Result<JobEntity, NetworkError> {
+        let result = await service.fetchJob()
         switch result {
         case .success(let dto):
             guard let entity = dto.data?.toJobEntity() else {

--- a/CERTI-iOS/Domain/Interfaces/Repositories/JobRepository.swift
+++ b/CERTI-iOS/Domain/Interfaces/Repositories/JobRepository.swift
@@ -10,6 +10,6 @@ import Foundation
 import Moya
 
 protocol JobRepository {
-    func getFetchJob() async -> Result<JobEntity, NetworkError>
+    func fetchJob() async -> Result<JobEntity, NetworkError>
     func editJob(jobNameList: JobEntity) async -> Result<Void, NetworkError>
 }

--- a/CERTI-iOS/Domain/UseCases/FetchJobUseCase.swift
+++ b/CERTI-iOS/Domain/UseCases/FetchJobUseCase.swift
@@ -17,6 +17,6 @@ final class DefaultFetchJobUseCase: FetchJobUseCase {
     }
     
     func execute() async -> Result<JobEntity, NetworkError> {
-        return await repository.getFetchJob()
+        return await repository.fetchJob()
     }
 }

--- a/CERTI-iOS/Presentation/Resume/Factory/ResumeFactory.swift
+++ b/CERTI-iOS/Presentation/Resume/Factory/ResumeFactory.swift
@@ -12,6 +12,8 @@ protocol ResumeFactory {
 }
 
 final class DefaultResumeFactory: ResumeFactory {
+    let fetchJobUseCase: FetchJobUseCase
+    
     let fetchAcquisitionListUseCase: FetchAcquisitionListUseCase
     let fetchAcquisitionDetailUseCase: FetchAcquisitionDetailUseCase
     let deleteAcquisitionUseCase: DeleteAcquisitionUseCase
@@ -25,6 +27,7 @@ final class DefaultResumeFactory: ResumeFactory {
     let fetchActivityListUseCase: FetchActivityListUseCase
     
     init(
+        fetchJobUseCase: FetchJobUseCase,
         fetchAcquisitionListUseCase: FetchAcquisitionListUseCase,
         fetchAcquisitionDetailUseCase: FetchAcquisitionDetailUseCase,
         deleteAcquisitionUseCase: DeleteAcquisitionUseCase,
@@ -35,6 +38,7 @@ final class DefaultResumeFactory: ResumeFactory {
         deleteActivityUseCase: DeleteActivityUseCase,
         fetchActivityListUseCase: FetchActivityListUseCase
     ) {
+        self.fetchJobUseCase = fetchJobUseCase
         self.fetchAcquisitionListUseCase = fetchAcquisitionListUseCase
         self.fetchAcquisitionDetailUseCase = fetchAcquisitionDetailUseCase
         self.deleteAcquisitionUseCase = deleteAcquisitionUseCase
@@ -49,6 +53,7 @@ final class DefaultResumeFactory: ResumeFactory {
     @MainActor
     func makeResumeViewModel() -> ResumeViewModel {
         ResumeViewModel(
+            fetchJobUseCase: fetchJobUseCase,
             fetchAcquisitionListUseCase: fetchAcquisitionListUseCase,
             fetchAcquisitionDetailUseCase: fetchAcquisitionDetailUseCase,
             deleteAcquisitionUseCase: deleteAcquisitionUseCase,

--- a/CERTI-iOS/Presentation/Resume/View/MyCareerEditView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/MyCareerEditView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct MyCareerEditView: View {
-    @EnvironmentObject var resumeCoordinator: ResumeCoordinator
     @ObservedObject var viewModel: ResumeViewModel
     @State var isDeleteAlertPresented = false
     @State var selectedCareersIndex : Int? = nil
@@ -19,13 +18,13 @@ struct MyCareerEditView: View {
         ZStack {
             VStack(alignment: .leading, spacing: 0) {
                 BackButton {
-                    resumeCoordinator.pop()
+                    viewModel.resumeViewRoutePop()
                 }
                 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
                         Button {
-                            resumeCoordinator.push(next: .myCareerWriteView)
+                            viewModel.navigateToCareerWrite()
                         } label: {
                             HStack(alignment: .center, spacing: 0) {
                                 Image(.iconPlus)

--- a/CERTI-iOS/Presentation/Resume/View/MyCareerEditView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/MyCareerEditView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MyCareerEditView: View {
     @ObservedObject var viewModel: ResumeViewModel
+    
     @State var isDeleteAlertPresented = false
     @State var selectedCareersIndex : Int? = nil
     

--- a/CERTI-iOS/Presentation/Resume/View/MyCareerWriteView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/MyCareerWriteView.swift
@@ -8,13 +8,12 @@
 import SwiftUI
 
 struct MyCareerWriteView: View {
-    @EnvironmentObject var resumeCoordinator: ResumeCoordinator
     @ObservedObject var viewModel: ResumeViewModel
     
     var body: some View {
             VStack (alignment: .leading, spacing: 0) {
                 BackButton() {
-                    resumeCoordinator.pop()
+                    viewModel.resumeViewRoutePop()
                 }
                 
                 ScrollView {
@@ -33,7 +32,7 @@ struct MyCareerWriteView: View {
                             action: {
                                 Task {
                                     await viewModel.addCareer(resumeModel: viewModel.resumeModel)
-                                    resumeCoordinator.pop()
+                                    viewModel.resumeViewRoutePop()
                                 }
                             },
                             textEmpty: .constant(viewModel.isWriteButtonEnabled)

--- a/CERTI-iOS/Presentation/Resume/View/MyCertificateEditView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/MyCertificateEditView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct MyCertificateEditView: View {
-    @EnvironmentObject var resumeCoordinator: ResumeCoordinator
     @ObservedObject var viewModel: ResumeViewModel
     @State var isDeleteAlertPresented = false
     @State var selectedIndex : Int? = nil
@@ -19,7 +18,7 @@ struct MyCertificateEditView: View {
         ZStack {
             VStack(alignment: .leading, spacing: 0) {
                 BackButton {
-                    resumeCoordinator.pop()
+                    viewModel.resumeViewRoutePop()
                 }
                 
                 ScrollView(.vertical) {

--- a/CERTI-iOS/Presentation/Resume/View/MyExtracurricularActivityEditView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/MyExtracurricularActivityEditView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct MyExtracurricularActivityEditView: View {
-    @EnvironmentObject var resumeCoordinator: ResumeCoordinator
     @ObservedObject var viewModel: ResumeViewModel
     @State var isDeleteAlertPresented = false
     @State var selectedActivityIndex : Int? = nil
@@ -20,13 +19,13 @@ struct MyExtracurricularActivityEditView: View {
         ZStack {
             VStack(alignment: .leading, spacing: 0) {
                 BackButton {
-                    resumeCoordinator.pop()
+                    viewModel.resumeViewRoutePop()
                 }
                 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
                         Button {
-                            resumeCoordinator.push(next: .myExtracurricularActivityWriteView)
+                            viewModel.navigateToActivityWrite()
                         } label: {
                             HStack(alignment: .center, spacing: 0) {
                                 Image(.iconPlus)

--- a/CERTI-iOS/Presentation/Resume/View/MyExtracurricularActivityWriteView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/MyExtracurricularActivityWriteView.swift
@@ -8,13 +8,12 @@
 import SwiftUI
 
 struct MyExtracurricularActivityWriteView: View {
-    @EnvironmentObject var resumeCoordinator: ResumeCoordinator
     @ObservedObject var viewModel: ResumeViewModel
     
     var body: some View {
             VStack (alignment: .leading, spacing: 0) {
                 BackButton() {
-                    resumeCoordinator.pop()
+                    viewModel.resumeViewRoutePop()
                 }
                 
                 ScrollView {
@@ -34,7 +33,7 @@ struct MyExtracurricularActivityWriteView: View {
                                 Task {
                                     await viewModel.addActivity(resumeModel: viewModel.resumeModel)
                                     viewModel.clearResumeModel()
-                                    resumeCoordinator.pop()
+                                    viewModel.resumeViewRoutePop()
                                 }
                             },
                             textEmpty: .constant(viewModel.isWriteButtonEnabled)

--- a/CERTI-iOS/Presentation/Resume/View/ResumeCoordinatorView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/ResumeCoordinatorView.swift
@@ -24,6 +24,24 @@ struct ResumeCoordinatorView: View {
     var body: some View {
         NavigationStack(path: $resumeCoordinator.path) {
             ResumeView(viewModel: resumeViewModel)
+                .onChange(of: resumeViewModel.resumeViewRoute) { route in
+                    guard let route = route else { return }
+                    switch route {
+                    case .navigateToActivityEdit:
+                        resumeCoordinator.push(next: .myExtracurricularActivityEditView)
+                    case .navigateToCareerWrite:
+                        resumeCoordinator.push(next: .myCareerWriteView)
+                    case .navigateToActivityWrite:
+                        resumeCoordinator.push(next: .myExtracurricularActivityWriteView)
+                    case .navigateToCertificatedEdit:
+                        resumeCoordinator.push(next: .myCertificateEdit)
+                    case .navigateToCareerEdit:
+                        resumeCoordinator.push(next: .myCareerEdit)
+                    case .resumeViewRoutePop:
+                        resumeCoordinator.pop()
+                    }
+                    resumeViewModel.resumeViewRoute = nil
+                }
                 .navigationDestination(for: ResumeRoute.self) { route in
                     switch route {
                     case .myCertificateEdit:

--- a/CERTI-iOS/Presentation/Resume/View/ResumeView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/ResumeView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct ResumeView: View {
-    @EnvironmentObject var resumeCoordinator: ResumeCoordinator
     @ObservedObject var viewModel: ResumeViewModel
     @State private var selectedCard: CertificatedDetailModel? = nil
 
@@ -139,7 +138,7 @@ extension ResumeView {
             Spacer()
             
             Button {
-                resumeCoordinator.push(next: .myCertificateEdit)
+                viewModel.navigateToCertificatedEdit()
             } label: {
                 Image(.iconArrowright36)
             }
@@ -204,7 +203,7 @@ extension ResumeView {
             Spacer()
             
             Button {
-                resumeCoordinator.push(next: .myCareerEdit)
+                viewModel.navigateToCareerEdit()
             } label: {
                 Image(.iconArrowright36)
             }
@@ -265,7 +264,7 @@ extension ResumeView {
             Spacer()
             
             Button {
-                resumeCoordinator.push(next: .myExtracurricularActivityEditView)
+                viewModel.navigateToActivityEdit()
             } label: {
                 Image(.iconArrowright36)
             }

--- a/CERTI-iOS/Presentation/Resume/ViewModel/ResumeViewModel.swift
+++ b/CERTI-iOS/Presentation/Resume/ViewModel/ResumeViewModel.swift
@@ -32,10 +32,8 @@ final class ResumeViewModel: ObservableObject {
     var isWriteButtonEnabled: Bool {
         !resumeModel.name.isBlank && !resumeModel.place.isBlank && !resumeModel.description.isBlank && isPeriodFilled
     }
-    private let jobService = AppDIContainer.shared.jobRepository
-    private let acquisitionService = AppDIContainer.shared.acquisitionRepository
-    private let careersService = AppDIContainer.shared.careersRepository
-    private let activityService = AppDIContainer.shared.activityRepository
+    
+    private let fetchJobUseCase: FetchJobUseCase
     
     private let fetchAcquisitionListUseCase: FetchAcquisitionListUseCase
     private let fetchAcquisitionDetailUseCase: FetchAcquisitionDetailUseCase
@@ -50,6 +48,7 @@ final class ResumeViewModel: ObservableObject {
     private let fetchActivityListUseCase: FetchActivityListUseCase
     
     init(
+        fetchJobUseCase: FetchJobUseCase,
         fetchAcquisitionListUseCase: FetchAcquisitionListUseCase,
         fetchAcquisitionDetailUseCase: FetchAcquisitionDetailUseCase,
         deleteAcquisitionUseCase: DeleteAcquisitionUseCase,
@@ -60,6 +59,7 @@ final class ResumeViewModel: ObservableObject {
         deleteActivityUseCase: DeleteActivityUseCase,
         fetchActivityListUseCase: FetchActivityListUseCase
     ) {
+        self.fetchJobUseCase = fetchJobUseCase
         self.fetchAcquisitionListUseCase = fetchAcquisitionListUseCase
         self.fetchAcquisitionDetailUseCase = fetchAcquisitionDetailUseCase
         self.deleteAcquisitionUseCase = deleteAcquisitionUseCase
@@ -89,21 +89,16 @@ final class ResumeViewModel: ObservableObject {
 
 extension ResumeViewModel {
     func getJobList() async {
-//        let result = await jobService.getFetchJob()
-//        
-//        switch result {
-//        case .success(let response):
-//            guard let data = response.data else {
-//                logger.error("❌ getJobList: No data received")
-//                return
-//            }
-//            
-//            self.jobList = data.jobList
-//            logger.debug("✅ getJobList success: \(data.jobList)")
-//            
-//        case .failure(let error):
-//            logger.error("getJobList failed: \(error.localizedDescription)")
-//        }
+        let result = await fetchJobUseCase.execute()
+        
+        switch result {
+        case .success(let response):
+            logger.info("✅ 희망직무 조회 성공")
+            self.jobList = response.toJobListModel().jobList
+            
+        case .failure(let error):
+            logger.error("❌ 희망직무 조회 실패: \(error.localizedDescription)")
+        }
     }
     
     func getAcquisitionList() async {

--- a/CERTI-iOS/Presentation/Resume/ViewModel/ResumeViewModel.swift
+++ b/CERTI-iOS/Presentation/Resume/ViewModel/ResumeViewModel.swift
@@ -11,9 +11,8 @@ import os
 
 enum ResumeViewRoute {
     case navigateToCareerWrite
-    case navigateToActivityWirte
+    case navigateToActivityWrite
     case navigateToCertificatedEdit
-    case navigateToCardDetail
     case navigateToCareerEdit
     case navigateToActivityEdit
     
@@ -105,16 +104,12 @@ extension ResumeViewModel {
         resumeViewRoute = .navigateToCareerWrite
     }
     
-    func navigateToActivityWirte() {
-        resumeViewRoute = .navigateToActivityWirte
+    func navigateToActivityWrite() {
+        resumeViewRoute = .navigateToActivityWrite
     }
 
     func navigateToCertificatedEdit() {
         resumeViewRoute = .navigateToCertificatedEdit
-    }
-    
-    func navigateToCardDetail() {
-        resumeViewRoute = .navigateToCardDetail
     }
     
     func navigateToCareerEdit() {

--- a/CERTI-iOS/Presentation/Resume/ViewModel/ResumeViewModel.swift
+++ b/CERTI-iOS/Presentation/Resume/ViewModel/ResumeViewModel.swift
@@ -22,9 +22,6 @@ enum ResumeViewRoute {
 @MainActor
 final class ResumeViewModel: ObservableObject {
     @Published var resumeViewRoute: ResumeViewRoute?
-    @Published var careerDummy: [ResumeModel] = ResumeModel.myCareerDummy()
-    @Published var myExtracurricularActivityModelDummy: [ResumeModel] = ResumeModel.myExtracurricularActivityDummy()
-    @Published var certificatedDummy: [CertificatedModel] = CertificatedModel.dummy()
     @Published var jobList: [String] = []
     @Published var acquisitionList: [CertificatedModel] = []
     @Published var acquisitionDetail: CertificatedDetailModel? = nil

--- a/CERTI-iOS/Presentation/Resume/ViewModel/ResumeViewModel.swift
+++ b/CERTI-iOS/Presentation/Resume/ViewModel/ResumeViewModel.swift
@@ -9,8 +9,20 @@ import Foundation
 
 import os
 
+enum ResumeViewRoute {
+    case navigateToCareerWrite
+    case navigateToActivityWirte
+    case navigateToCertificatedEdit
+    case navigateToCardDetail
+    case navigateToCareerEdit
+    case navigateToActivityEdit
+    
+    case resumeViewRoutePop
+}
+
 @MainActor
 final class ResumeViewModel: ObservableObject {
+    @Published var resumeViewRoute: ResumeViewRoute?
     @Published var careerDummy: [ResumeModel] = ResumeModel.myCareerDummy()
     @Published var myExtracurricularActivityModelDummy: [ResumeModel] = ResumeModel.myExtracurricularActivityDummy()
     @Published var certificatedDummy: [CertificatedModel] = CertificatedModel.dummy()
@@ -82,6 +94,40 @@ final class ResumeViewModel: ObservableObject {
         isPeriodFilled = false
     }
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "CERTI", category: "resume")
+}
+
+
+// MARK: - Navigation Func
+
+extension ResumeViewModel {
+    
+    func navigateToCareerWrite() {
+        resumeViewRoute = .navigateToCareerWrite
+    }
+    
+    func navigateToActivityWirte() {
+        resumeViewRoute = .navigateToActivityWirte
+    }
+
+    func navigateToCertificatedEdit() {
+        resumeViewRoute = .navigateToCertificatedEdit
+    }
+    
+    func navigateToCardDetail() {
+        resumeViewRoute = .navigateToCardDetail
+    }
+    
+    func navigateToCareerEdit() {
+        resumeViewRoute = .navigateToCareerEdit
+    }
+    
+    func navigateToActivityEdit() {
+        resumeViewRoute = .navigateToActivityEdit
+    }
+    
+    func resumeViewRoutePop() {
+        resumeViewRoute = .resumeViewRoutePop
+    }
 }
 
 


### PR DESCRIPTION
## 🌴 작업한 브랜치
<!-- 예시: `feat/#131` -->
`refactor/#154`

## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- fetchJobUseCase로 뷰모델 변경하고 Factory와 DIContainer 수정하였습니다.
- 코디네이터 리팩토링

저가요 변경된 코디네이터에 대해서 이해한 부분을 설명해보겠습니다. 지적해주시면 감사드리겠습니다.
1. 기존: 뷰에서 직접 변경할 뷰 상태를 코디네이터에게 넘겨줘서 화면을 바꿈
2. 클린아키텍처의 관점으로 보았을 때 뷰에서는 뷰모델만 알아야한다는 원칙을 지키기 위해서 뷰에서 코디네이터를 걷어내기로 함
3. 뷰는 뷰모델을 통해서 화면 변경 상태를 변경하는 함수만 호출
4. 뷰모델에서 Enum으로 상태를 관리하여 뷰에서 호출한대로 값을 변경
5. CoordinatorView에서 .onChange를 통해 변경 감지
6. 감지되면 .navigationDestination가 뷰를 변경
이상입니다.
<!--
```swift
넣고싶은 코드가 있다면 적어주세요
```
-->


## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #154 
