### PR TITLE
[Refactor] #182 - 멘토 코드 리뷰 반영 및 수정사항

### DIFF
--- a/CERTI-iOS/Domain/UseCases/PreviewStub/ResumePreviewStub.swift
+++ b/CERTI-iOS/Domain/UseCases/PreviewStub/ResumePreviewStub.swift
@@ -1,0 +1,95 @@
+//
+//  ResumePreviewStub.swift
+//  CERTI-iOS
+//
+//  Created by 이상엽 on 11/4/25.
+//
+
+import Foundation
+
+struct PreviewFetchJobUseCase: FetchJobUseCase {
+    func execute() async -> Result<JobEntity, NetworkError> {
+        let dummy = JobEntity(jobs: ["IT/인터넷", "건설", "금융"])
+        return .success(dummy)
+    }
+}
+
+struct PreviewFetchAcquisitionListUseCase: FetchAcquisitionListUseCase {
+    func execute() async -> Result<AcquisitionListEntity, NetworkError> {
+        let dummy = AcquisitionListEntity(
+            acquisitionList: [
+                AcquisitionListEntityData(acquisitionId: 1, cardFrontImageUrl: "https://dummy.certified.com/image_certification_card_large_1.png", index: 1, name: "정보처리기사",  tags: ["컴퓨터"], description: "정처기 자격증 설명", createdAt: "2026.05.10"),
+                AcquisitionListEntityData(acquisitionId: 2, cardFrontImageUrl: "https://dummy.certified.com/image_certification_card_large_1.png", index: 2, name: "GTQ 1급",  tags: ["디자인"], description: "그래픽 자격증 설명", createdAt: "2025.11.10"),
+            ]
+        )
+        return .success(dummy)
+    }
+}
+
+struct PreviewFetchAcquisitionDetailUseCase: FetchAcquisitionDetailUseCase {
+    func excute(id: Int) async -> Result<AcquisitionDetailEntity, NetworkError> {
+        let dummy = AcquisitionDetailEntity(
+            acquisitionDetail: AcquisitionDetailEntityData(
+                acquisitionId: 1,
+                cardFrontImageUrl: "https://dummy.certified.com/image_certification_card_large_1.png",
+                cardBackImageUrl: "https://dummy.certified.com/image_certification_card_large_1.png",
+                index: 1,
+                name: "정보처리기사",
+                tags: ["컴퓨터"],
+                description: "정처기 자격증 설명",
+                createdAt: "2026.05.10"
+            )
+        )
+        return .success(dummy)
+    }
+}
+
+struct PreviewFetchActivityListUseCase: FetchActivityListUseCase {
+    func execute() async -> Result<ActivityListEntity, NetworkError> {
+        let dummyActivities = ActivityListEntity(list:[
+            ResumeEntityData(startAt: "2022.03", endAt: "2022.12", name: "SOPT 35기 iOS", place: "SOPT", description: "CERTI 앱 개발 프로젝트 진행"),
+            ResumeEntityData(startAt: "2023.03", endAt: "2023.07", name: "학교 창업동아리", place: "성균관대", description: "서비스 아이디어 기획 및 발표")
+        ])
+        return .success(dummyActivities)
+    }
+}
+
+struct PreviewFetchCareersListUseCase: FetchCareersListUseCase {
+    func execute() async -> Result<CareersListEntity, NetworkError> {
+        let dummyCareers = CareersListEntity(list:[
+            ResumeEntityData(careerId: 1, startAt: "2021.11", endAt: "2022.01", name: "패션디자이너 인턴", place: "서티그룹", description: "트렌드 리서치"),
+            ResumeEntityData(careerId: 2, startAt: "2023.02", endAt: "2023.07", name: "iOS 개발 인턴", place: "CERTI", description: "CERTI 앱 개발 참여")
+        ])
+        return .success(dummyCareers)
+    }
+}
+
+struct PreviewAddCareersUseCase: AddCareersUseCase {
+    func execute(request: CareersEntity) async -> Result<Bool, NetworkError> {
+        .success(true)
+    }
+}
+
+struct PreviewDeleteCareersUserCase: DeleteCareersUseCase {
+    func execute(id: Int) async -> Result<Void, NetworkError> {
+        return .success(())
+    }
+}
+
+struct PreviewAddActivityUseCase: AddActivityUseCase {
+    func execute(request: ActivityEntity) async -> Result<Void, NetworkError> {
+        return .success(())
+    }
+}
+
+struct PreviewDeleteActivityUseCase: DeleteActivityUseCase {
+    func execute(id: Int) async -> Result<Void, NetworkError> {
+        return .success(())
+    }
+}
+
+struct PreviewDeleteAcquisitionUseCase: DeleteAcquisitionUseCase {
+    func execute(id: Int) async -> Result<Void, NetworkError> {
+        return .success(())
+    }
+}

--- a/CERTI-iOS/Domain/UseCases/PreviewUseCases/ResumePreviewUseCase.swift
+++ b/CERTI-iOS/Domain/UseCases/PreviewUseCases/ResumePreviewUseCase.swift
@@ -1,5 +1,5 @@
 //
-//  ResumePreviewStub.swift
+//  ResumePreviewUseCase.swift
 //  CERTI-iOS
 //
 //  Created by 이상엽 on 11/4/25.

--- a/CERTI-iOS/Presentation/Resume/Components/ResumeActivityListComponent.swift
+++ b/CERTI-iOS/Presentation/Resume/Components/ResumeActivityListComponent.swift
@@ -48,5 +48,11 @@ struct ResumeActivityListComponent: View {
 }
 
 #Preview {
-    ResumeActivityListComponent(model: ResumeModel.myCareerDummy().first!)
+    ResumeActivityListComponent(model: ResumeModel(
+        startAt: "2021.11",
+        endAt: "2022.01",
+        name: "패션디자이너 인턴",
+        place: "서티그룹",
+        description: "트렌드 리서치 및 소재 조사"
+    ))
 }

--- a/CERTI-iOS/Presentation/Resume/Models/ResumeModel.swift
+++ b/CERTI-iOS/Presentation/Resume/Models/ResumeModel.swift
@@ -20,23 +20,6 @@ struct ResumeModel: Identifiable {
 }
 
 extension ResumeModel {
-    static func myCareerDummy() -> [ResumeModel] {
-        return [ ResumeModel(startAt: "2021.11", endAt: "2022.01", name: "패션디자이너 인턴ㅇ", place: "서티그룹ㅇㅇㅇㅇㅇㅇ", description: "트렌드 리서치 및 소재 조사ㅇ"),
-                 ResumeModel(startAt: "2021.11", endAt: "2022.01", name: "패션디자이너 인턴ㅇ", place: "서티그룹ㅇㅇㅇㅇㅇㅇ", description: "트렌드 리서치 및 소재 조사ㅇ"),
-                 ResumeModel(startAt: "2021.11", endAt: "2022.01", name: "패션디자이너 인턴ㅇ", place: "서티그룹ㅇㅇㅇㅇㅇㅇ", description: "트렌드 리서치 및 소재 조사ㅇ"),
-                 ResumeModel(startAt: "2021.11", endAt: "2022.01", name: "패션디자이너 인턴ㅇ", place: "서티그룹ㅇㅇㅇㅇㅇㅇ", description: "트렌드 리서치 및 소재 조사ㅇ"),
-        ]
-    }
-    
-    static func myExtracurricularActivityDummy() -> [ResumeModel] {
-        return [ ResumeModel(startAt: "2021.11", endAt: "2022.01", name: "동아리 36기 기획", place: "SOPTㅇㅇㅇㅇㅇㅇ", description: "서비스 기획 및 아이디어 도출"),
-                 ResumeModel(startAt: "2021.11", endAt: "2022.01", name: "동아리 36기 기획", place: "SOPTㅇㅇㅇㅇㅇㅇ", description: "서비스 기획 및 아이디어 도출"),
-                 ResumeModel(startAt: "2021.11", endAt: "2022.01", name: "동아리 36기 기획", place: "SOPTㅇㅇㅇㅇㅇㅇ", description: "서비스 기획 및 아이디어 도출"),
-                 ResumeModel(startAt: "2021.11", endAt: "2022.01", name: "동아리 36기 기획", place: "SOPTㅇㅇㅇㅇㅇㅇ", description: "서비스 기획 및 아이디어 도출"),
-        ]
-    }}
-
-extension ResumeModel {
     
     
     // MARK: - Func

--- a/CERTI-iOS/Presentation/Resume/View/CertificateCardDetailView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/CertificateCardDetailView.swift
@@ -126,6 +126,8 @@ extension CertificateCardDetailView {
     
     private var CertificateCardDetailViewBack: some View {
             ZStack(alignment: .center) {
+                Color.blackOpacity40
+                    .frame(width: 250, height: 375)
                 KFImage(URL(string: card.cardBackImageUrl))
                     .retry(maxCount: 3, interval: .seconds(5))
                     .onFailure { error in
@@ -133,6 +135,7 @@ extension CertificateCardDetailView {
                     }
                     .resizable()
                     .scaledToFill()
+                    .frame(width: 250, height: 375)
                 
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(alignment: .center, spacing: 0) {

--- a/CERTI-iOS/Presentation/Resume/View/ResumeView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/ResumeView.swift
@@ -46,15 +46,13 @@ struct ResumeView: View {
                 }
             }
         }
-        .onAppear{
-            Task {
-                async let jobList: () = viewModel.getJobList()
-                async let acquisitionList: () = viewModel.getAcquisitionList()
-                async let careersList: () = viewModel.getCareersList()
-                async let activityList:() = viewModel.getActivityList()
-                
-                _ = await (jobList, acquisitionList, careersList, activityList)
-            }
+        .task {
+            async let jobList: () = viewModel.getJobList()
+            async let acquisitionList: () = viewModel.getAcquisitionList()
+            async let careersList: () = viewModel.getCareersList()
+            async let activityList: () = viewModel.getActivityList()
+            
+            _ = await (jobList, acquisitionList, careersList, activityList)
         }
     }
 }

--- a/CERTI-iOS/Presentation/Resume/View/ResumeView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/ResumeView.swift
@@ -312,3 +312,20 @@ extension ResumeView {
         }
     }
 }
+
+#Preview {
+    ResumeView(
+        viewModel: ResumeViewModel(
+            fetchJobUseCase: PreviewFetchJobUseCase(),
+            fetchAcquisitionListUseCase: PreviewFetchAcquisitionListUseCase(),
+            fetchAcquisitionDetailUseCase: PreviewFetchAcquisitionDetailUseCase(),
+            deleteAcquisitionUseCase: PreviewDeleteAcquisitionUseCase(),
+            addCareersUseCase: PreviewAddCareersUseCase(),
+            deleteCareersUseCase: PreviewDeleteCareersUserCase(),
+            fetchCareersListUseCase: PreviewFetchCareersListUseCase(),
+            addActivityUseCase: PreviewAddActivityUseCase(),
+            deleteActivityUseCase: PreviewDeleteActivityUseCase(),
+            fetchActivityListUseCase: PreviewFetchActivityListUseCase()
+        )
+    )
+}

--- a/CERTI-iOS/Presentation/Resume/View/ResumeView.swift
+++ b/CERTI-iOS/Presentation/Resume/View/ResumeView.swift
@@ -48,10 +48,12 @@ struct ResumeView: View {
         }
         .onAppear{
             Task {
-                await viewModel.getJobList()
-                await viewModel.getAcquisitionList()
-                await viewModel.getCareersList()
-                await viewModel.getActivityList()
+                async let jobList: () = viewModel.getJobList()
+                async let acquisitionList: () = viewModel.getAcquisitionList()
+                async let careersList: () = viewModel.getCareersList()
+                async let activityList:() = viewModel.getActivityList()
+                
+                _ = await (jobList, acquisitionList, careersList, activityList)
             }
         }
     }


### PR DESCRIPTION
## 🌴 작업한 브랜치
<!-- 예시: `feat/#131` -->
`refactor/#182` 

## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- async let으로 Task 병렬 처리 
- ResumeModel에서 더미 데이터 삭제
- Domain/UseCases 밑에 PreviewUseCases 폴더를 만들어서 ResumePreviewUseCase를 만들었습니다. 이 UseCase는 테스트까지는 아니지만 Preview를 위한 용도로 만들어졌습니다. (후에 테스트 코드 작성도 해보고 싶음...) 프리뷰를 쓰려고 하는 이유는 스프린트 시에 뷰 변경 내용을 편하게 확인하기 위함입니다. 더 조은 방법이 있다면 가티 얘기해보아요.
- .task 수정자를 이용해서 Task를 취소할 수 있도록 수정.
```swift
//기존방식
.onAppear {
    Task {
        await viewModel.loadData()
    }
}

//변경된 방식
.task {
    await viewModel.loadData()
}
```
기존 방식은 뷰가 렌더링 될 때 Task가 시작되지만 뷰가 사라져도 Task가 취소되지 않는다. 그래서 뷰를 마구마구 이동하게 된다면 성능, 메모리 문제가 생길 것이다? 그래서 직접 Task를 관리해줘야 하는데 .task를 이용하게 되면 SwiftUI가 이 뷰를 렌더링 할 때 Task를 자동으로 실행하고 뷰가 사라지면 자동으로 취소시켜준대여. 정말 편한 것이어요. (iOS 15 이상부터 사용가능)

그리고 앱잼 때 해결 못한 카드 이미지가 움직이는 오류를 해결했습니다.
이 카드 뒤집기가 앞면 뒷면이 있는데 제가 뒷면 프레임 지정을 안 해놨더라고요. 그래서 저는 처음에 앞면만 보여지니까 앞면 프레임 잡았는데 왜!! 자꾸 움직이지 생각했습니다. 서버의 응답이 오기 전엔 플레이스홀더를 사용했는데도 움직이는 것이었어요. 근데 이 두 놈은 ZStack으로 묶여있는 것이었는데 이걸 생각을 못했습니다. 그래서 뒷면 프레임 정해주니까 중앙 정렬이 딱 됐네요. 흑



## 📸 스크린샷
프리뷰에는 이미지를 넣을 수가 없어서 일단 없는 채로 찍었어요. (넣을 수 있긴 한데 프리뷰를 위한 코드를 작성하기가 좀... 굳이 필요한가? 싶어서요..)
아래는 수정 전 화면입니다

https://github.com/user-attachments/assets/c8a67917-f247-4d13-af4b-a5b2d0308749

아래는 수정 후 입니다.

https://github.com/user-attachments/assets/314cf657-2275-40d0-8756-57c58f34ef97




## 📟 관련 이슈
- Resolved: #182 
